### PR TITLE
Change the success message for riskprofile command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/RiskProfileCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RiskProfileCommand.java
@@ -19,18 +19,20 @@ import seedu.address.model.person.RiskProfile;
  */
 public class RiskProfileCommand extends Command {
     public static final String COMMAND_WORD = "riskprofile";
-    public static final String MESSAGE_ADD_RISKPROFILE_SUCCESS = "Added risk profile to Person: %1$s";
-    public static final String MESSAGE_INVALID_RESULT = "Result must have 8 comma-separated characters from 'a' to 'e'."
+    public static final String MESSAGE_ADD_RISKPROFILE_SUCCESS = "Added risk profile to Person: %1$s; Phone: %2$s; "
+        + "Email: %3$s; Occupation: %4$s; Address: %5$s; "
+        + "Appointment Date: %6$s; Risk Profile: %7$s; Tags: %8$s";
+    public static final String MESSAGE_INVALID_RESULT = "Result must have 8 comma-separated characters from 'a' to 'e'!"
         + "\n%1$s";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds the risk profile of the person identified "
         + "by the index number used in the last person listing. "
         + "Existing risk profile will be overwritten by the input.\n"
-        + "Parameters: INDEX (must be a positive integer)"
+        + "Parameters: INDEX (must be a positive integer) "
         + PREFIX_RISKPROFILE + "[RESULT]\n"
         + "Example: " + COMMAND_WORD + " 1 "
         + PREFIX_RISKPROFILE + "a,e,b,d,c,a,d,e";
 
-    private final Index index;
+    private final Index personToEdit;
     private final RiskProfile result;
 
     /**
@@ -40,7 +42,7 @@ public class RiskProfileCommand extends Command {
     public RiskProfileCommand(Index index, RiskProfile result) {
         requireAllNonNull(index, result);
 
-        this.index = index;
+        this.personToEdit = index;
         this.result = result;
     }
 
@@ -48,7 +50,7 @@ public class RiskProfileCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         List<Person> lastShownList = model.getFilteredPersonList();
 
-        if (index.getZeroBased() >= lastShownList.size()) {
+        if (personToEdit.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
@@ -61,7 +63,7 @@ public class RiskProfileCommand extends Command {
 
         RiskProfile riskProfile = new RiskProfile(riskLevel);
 
-        Person personToEdit = lastShownList.get(index.getZeroBased());
+        Person personToEdit = lastShownList.get(this.personToEdit.getZeroBased());
         Person editedPerson = new Person(
             personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(), personToEdit.getOccupation(),
             personToEdit.getAddress(), personToEdit.getApptDate(), riskProfile, personToEdit.getTags());
@@ -78,7 +80,15 @@ public class RiskProfileCommand extends Command {
      * {@code personToEdit}.
      */
     private String generateSuccessMessage(Person personToEdit) {
-        return String.format(MESSAGE_ADD_RISKPROFILE_SUCCESS, personToEdit);
+        return String.format(MESSAGE_ADD_RISKPROFILE_SUCCESS,
+            personToEdit.getName(),
+            personToEdit.getPhone(),
+            personToEdit.getEmail(),
+            personToEdit.getOccupation(),
+            personToEdit.getAddress(),
+            personToEdit.getApptDate(),
+            personToEdit.getRiskProfile(),
+            personToEdit.getTags());
     }
 
     /**
@@ -177,7 +187,7 @@ public class RiskProfileCommand extends Command {
         }
 
         RiskProfileCommand e = (RiskProfileCommand) other;
-        return index.equals(e.index)
+        return personToEdit.equals(e.personToEdit)
             && result.equals(e.result);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/RiskProfileCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RiskProfileCommandTest.java
@@ -47,7 +47,9 @@ public class RiskProfileCommandTest {
         String expectedRiskLevel = RiskProfileCommand.calculateRiskLevel(totalScore);
 
         String expectedMessage = String.format(RiskProfileCommand.MESSAGE_ADD_RISKPROFILE_SUCCESS,
-            new PersonBuilder(firstPerson).withRiskProfile(expectedRiskLevel).build());
+            editedPerson.getName(), editedPerson.getPhone(), editedPerson.getEmail(),
+            editedPerson.getOccupation(), editedPerson.getAddress(), editedPerson.getApptDate(),
+            expectedRiskLevel, editedPerson.getTags());
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(firstPerson, editedPerson);
@@ -70,8 +72,9 @@ public class RiskProfileCommandTest {
         String expectedRiskLevel = RiskProfileCommand.calculateRiskLevel(totalScore);
 
         String expectedMessage = String.format(RiskProfileCommand.MESSAGE_ADD_RISKPROFILE_SUCCESS,
-            new PersonBuilder(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()))
-            .withRiskProfile(expectedRiskLevel).build());
+            editedPerson.getName(), editedPerson.getPhone(), editedPerson.getEmail(),
+            editedPerson.getOccupation(), editedPerson.getAddress(), editedPerson.getApptDate(),
+            expectedRiskLevel, editedPerson.getTags());
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(firstPerson, editedPerson);


### PR DESCRIPTION
Remove the package and class name from the success message of riskprofile command

This commit is to enhance the financial advisor's readability for the success message